### PR TITLE
Usage command refactor

### DIFF
--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 use self::regex::{Regex, Captures};
 
 use settings;
-use message::{Message, TransportType};
+use message::{Message, TransportType, DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
@@ -121,13 +121,15 @@ impl<'a> Command for KarmaCommand<'a> {
 
         // SEND MESSAGES
         let karma_telegram = karma_irc.clone();
+        let destination_irc: DestinationType = DestinationType::klone(&msg.to);
+        let destination_telegram: DestinationType = DestinationType::klone(&msg.to);
         match msg.from_transport {
             TransportType::IRC => {
                 to_irc.send(Message::new(
                     TransportType::Telegram,
                     karma_irc,
                     String::from("KarmaCommand"),
-                    String::from("karma"),
+                     destination_irc,
                     true,
                 ));
             }
@@ -136,7 +138,7 @@ impl<'a> Command for KarmaCommand<'a> {
                     TransportType::IRC,
                     karma_telegram,
                     String::from("KarmaCommand"),
-                    String::from("karma"),
+                    destination_telegram,
                     true,
                 ));
             }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -11,7 +11,7 @@ use self::regex::Regex;
 use self::chrono::{Local, NaiveDateTime};
 
 use settings;
-use message::{Message, TransportType};
+use message::{Message, TransportType,DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
@@ -98,20 +98,22 @@ impl<'a> Command for LastSeenCommand<'a> {
         for cap in re_get.captures_iter(&msg.text) {
             debug!("Last seen captures {:#?}", cap);
             let last_seen_irc = self.get(&cap[1]);
-            // SEND MESSAGES
             let last_seen_telegram = last_seen_irc.clone();
+            let destination_irc: DestinationType = DestinationType::klone(&msg.to);
+            let destination_telegram: DestinationType = DestinationType::klone(&msg.to);
+            // SEND MESSAGES
             to_irc.send(Message::new(
                 TransportType::Telegram,
                 last_seen_irc,
                 String::from("LastSeenCommand"),
-                self.name.to_owned(),
+                destination_irc,
                 true,
             ));
             to_telegram.send(Message::new(
                 TransportType::IRC,
                 last_seen_telegram,
                 String::from("LastSeenCommand"),
-                self.name.to_owned(),
+                destination_telegram,
                 true,
             ));
         }

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -14,7 +14,7 @@ use self::chrono::Local;
 use self::rand::distributions::{IndependentSample, Range};
 
 use settings;
-use message::{Message, TransportType};
+use message::{Message, TransportType, DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -194,20 +194,22 @@ impl<'a> Command for QuoteCommand<'a> {
         }
 
         let quote_telegram = quote_irc.clone();
+        let destination_irc: DestinationType = DestinationType::klone(&msg.to);
+        let destination_telegram: DestinationType = DestinationType::klone(&msg.to);
 
         // SEND MESSAGES
         to_irc.send(Message::new(
             TransportType::Telegram,
             quote_irc,
             String::from("QuoteCommand"),
-            String::from("quote"),
+            destination_irc,
             true,
         ));
         to_telegram.send(Message::new(
             TransportType::IRC,
             quote_telegram,
             String::from("QuoteCommand"),
-            String::from("quote"),
+            destination_telegram,
             true,
         ));
     }

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -1,6 +1,6 @@
 extern crate regex;
 
-use message::{Message, TransportType};
+use message::{Message, TransportType,DestinationType};
 use chan::Sender;
 
 use self::regex::Regex;
@@ -54,6 +54,8 @@ impl<'a> Command for RelayMessageCommand<'a> {
         irc_sender: &Sender<Message>,
         telegram_sender: &Sender<Message>,
     ) {
+        let destination_irc: DestinationType = DestinationType::klone(&msg.to);
+        let destination_telegram: DestinationType = DestinationType::klone(&msg.to);
         match msg.from_transport {
             TransportType::IRC => {
                 debug!("Sending message to Telegram chan");
@@ -61,7 +63,7 @@ impl<'a> Command for RelayMessageCommand<'a> {
                     TransportType::IRC,
                     msg.strip_command(self.command_prefix),
                     msg.from.clone(),
-                    msg.to.clone(),
+                    destination_telegram,
                     msg.is_from_command,
                 ));
             }
@@ -71,7 +73,7 @@ impl<'a> Command for RelayMessageCommand<'a> {
                     TransportType::Telegram,
                     msg.strip_command(self.command_prefix),
                     msg.from.clone(),
-                    msg.to.clone(),
+                    destination_irc,
                     msg.is_from_command,
                 ));
             }

--- a/holysee/src/ircclient.rs
+++ b/holysee/src/ircclient.rs
@@ -10,7 +10,7 @@ pub mod client {
     use self::irc::client::prelude::*;
 
     use settings::Settings;
-    use message::{Message, TransportType};
+    use message::{Message, TransportType, DestinationType};
 
     fn main_to_irc_loop(
         from_main_queue: &Receiver<Message>,
@@ -67,7 +67,7 @@ pub mod client {
                             TransportType::IRC,
                             message_text,
                             srcnick,
-                            source,
+                            DestinationType::User(source),
                             false,
                         ));
                     }

--- a/holysee/src/message.rs
+++ b/holysee/src/message.rs
@@ -8,12 +8,33 @@ pub enum TransportType {
     Telegram,
 }
 
+#[derive(Debug, Clone)]
+pub enum DestinationType {
+    Channel(String),
+    User(String),
+    Unknown,
+}
+
+impl DestinationType {
+    pub fn klone(other: &DestinationType) -> DestinationType{
+        match other {
+            &DestinationType::Channel(ref s) => {
+                DestinationType::Channel(String::from(s.clone()))
+            },
+            &DestinationType::User(ref u) => {
+                DestinationType::Channel(String::from(u.clone()))
+            },
+            &DestinationType::Unknown => DestinationType::Unknown,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Message {
     pub from_transport: TransportType,
     pub text: String,
     pub from: String,
-    pub to: String,
+    pub to: DestinationType,
     pub is_from_command: bool,
 }
 
@@ -22,7 +43,7 @@ impl Message {
         from_transport: TransportType,
         text: String,
         from: String,
-        to: String,
+        to: DestinationType,
         is_from_command: bool,
     ) -> Message {
         Message {

--- a/holysee/src/telegram.rs
+++ b/holysee/src/telegram.rs
@@ -9,11 +9,11 @@ pub mod client {
 
     use self::futures::Stream;
     use self::telegram_bot::Api;
-    use self::telegram_bot::types::{ChatId, MessageKind, SendMessage, UpdateKind};
+    use self::telegram_bot::types::{ChatId, MessageKind, SendMessage, UpdateKind, Chat};
     use self::tokio_core::reactor::Core;
 
     use settings::Settings;
-    use message::{Message, TransportType};
+    use message::{Message, TransportType, DestinationType};
 
     fn main_to_telegram_loop(from_main_queue: &Receiver<Message>, token: &str, chat_id: i64) {
         let mut core = Core::new().unwrap();
@@ -63,14 +63,21 @@ pub mod client {
                                         }
                                     }
                                     // user is not present, should never happen
-                                    None => String::from("unset"),
+                                    None => String::from("user unset"),
                                 };
-                                debug!("Incoming Telegram message source: #cattedrale, text: {}, src_nick: {}, entities: {:?}", data, from, entities);
+                                let to: DestinationType = match m.chat {
+                                    Chat::Private(_) => DestinationType::User(from.clone()),
+                                    Chat::Group(g) => DestinationType::Channel(g.title),
+                                    Chat::Supergroup(s) => DestinationType::Channel(s.title),
+                                    Chat::Channel(c) => DestinationType::Channel(c.title),
+                                    Chat::Unknown(_) => DestinationType::Unknown,
+                                };
+                                debug!("Incoming Telegram message source: #cattedrale, text: {}, src_nick: {}, to: {:?}, entities: {:?}", data, from, to, entities);
                                 to_main_queue.send(Message::new(
                                     TransportType::Telegram,
                                     data,
                                     from,
-                                    String::from("-"),
+                                    to,
                                     false,
                                 ));
                             }


### PR DESCRIPTION
we want to implement the usage command that allows a user to receive, via private message,a brief explanation of the usage of the bot and the avialable commands.
to avoid spamming the channels on both telegram and irc, we want the usage command to be invoked in both a 1:1 chat and a channel/group and then reply 1:1 only to the user sending the command.
limitation: the user on telegram must click on the bot to perform the `/start` action to be able to receive private messages from the bot. 