### PR TITLE
wip on usage command

### DIFF
--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -2,60 +2,76 @@ extern crate regex;
 
 use chan::Sender;
 
-use settings;
+//use settings;
 use message::Message;
 
 pub trait Command {
     fn execute(&mut self, &Message, &Sender<Message>, &Sender<Message>);
     fn get_usage(&self) -> String;
+    fn is_enabled(&self) -> bool;
+    fn get_name(&self) -> String;
+    fn matches_message_text(&self, message: &Message) -> bool;
 }
-
-#[derive(Debug)]
-pub struct NullCommand;
-
-impl NullCommand {
-    pub fn new() -> NullCommand {
-        NullCommand
-    }
-}
-
-impl Command for NullCommand {
-    fn execute(&mut self, _: &Message, _: &Sender<Message>, _: &Sender<Message>) {}
-    fn get_usage(&self) -> String {
-        return String::from("null usage");
-    }
-}
+//
+//#[derive(Debug)]
+//pub struct NullCommand;
+//
+//impl NullCommand {
+//    pub fn new() -> NullCommand {
+//        NullCommand
+//    }
+//}
+//
+//impl Command for NullCommand {
+//    fn execute(&mut self, _: &Message, _: &Sender<Message>, _: &Sender<Message>) {}
+//    fn get_usage(&self) -> String {
+//        return String::from("null usage");
+//    }
+//    fn is_enabled(&self) -> bool {
+//        false
+//    }
+//    fn get_name(&self) -> String {
+//        String::from("null_command")
+//    }
+//    fn matches_message_text(&self, _: &Message) -> bool {
+//        false
+//    }
+//}
 
 pub struct CommandDispatcher<'a> {
-    command: &'a Command,
-    enabled_commands: &'a Vec<String>,
+    commands: Vec<&'a mut Command>,
+//    enabled_commands: &'a Vec<String>,
 }
 
 impl<'a> CommandDispatcher<'a> {
     pub fn new(
-        settings: &'a settings::Commands,
-        base_command: &'a Command,
+//        settings: &'a settings::Commands,
     ) -> CommandDispatcher<'a> {
         CommandDispatcher {
-            command: base_command,
-            enabled_commands: &settings.enabled,
+            commands: vec!(),
+//            enabled_commands: &settings.enabled,
         }
     }
 
-    pub fn is_command_enabled(&self, command: &str) -> bool {
-        self.enabled_commands.into_iter().any(|x| x == command)
-    }
+//    pub fn is_command_enabled(&self, command: &str) -> bool {
+//        self.enabled_commands.into_iter().any(|x| x == command)
+//    }
 
-    pub fn set_command(&mut self, cmd: &'a Command) {
-        self.command = cmd;
+    pub fn register(&mut self, cmd: &'a mut Command) {
+        self.commands.push(cmd);
     }
 
     pub fn execute(
-        &self,
+        &mut self,
         msg: &Message,
         irc_sender: &Sender<Message>,
         tg_sender: &Sender<Message>,
     ) {
-        self.command.execute(msg, irc_sender, tg_sender);
+        for command in self.commands.as_mut_slice() {
+            if command.matches_message_text(msg) {
+                debug!("execute() for {}", command.get_name());
+                command.execute(msg, irc_sender, tg_sender);
+            }
+        }
     }
 }

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -1,8 +1,6 @@
 extern crate regex;
 
 use chan::Sender;
-
-//use settings;
 use message::Message;
 
 pub trait Command {
@@ -12,50 +10,17 @@ pub trait Command {
     fn get_name(&self) -> String;
     fn matches_message_text(&self, message: &Message) -> bool;
 }
-//
-//#[derive(Debug)]
-//pub struct NullCommand;
-//
-//impl NullCommand {
-//    pub fn new() -> NullCommand {
-//        NullCommand
-//    }
-//}
-//
-//impl Command for NullCommand {
-//    fn execute(&mut self, _: &Message, _: &Sender<Message>, _: &Sender<Message>) {}
-//    fn get_usage(&self) -> String {
-//        return String::from("null usage");
-//    }
-//    fn is_enabled(&self) -> bool {
-//        false
-//    }
-//    fn get_name(&self) -> String {
-//        String::from("null_command")
-//    }
-//    fn matches_message_text(&self, _: &Message) -> bool {
-//        false
-//    }
-//}
 
 pub struct CommandDispatcher<'a> {
     commands: Vec<&'a mut Command>,
-//    enabled_commands: &'a Vec<String>,
 }
 
 impl<'a> CommandDispatcher<'a> {
-    pub fn new(
-//        settings: &'a settings::Commands,
-    ) -> CommandDispatcher<'a> {
+    pub fn new() -> CommandDispatcher<'a> {
         CommandDispatcher {
             commands: vec!(),
-//            enabled_commands: &settings.enabled,
         }
     }
-
-//    pub fn is_command_enabled(&self, command: &str) -> bool {
-//        self.enabled_commands.into_iter().any(|x| x == command)
-//    }
 
     pub fn register(&mut self, cmd: &'a mut Command) {
         self.commands.push(cmd);

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -17,9 +17,7 @@ pub struct CommandDispatcher<'a> {
 
 impl<'a> CommandDispatcher<'a> {
     pub fn new() -> CommandDispatcher<'a> {
-        CommandDispatcher {
-            commands: vec!(),
-        }
+        CommandDispatcher { commands: vec![] }
     }
 
     pub fn register(&mut self, cmd: &'a mut Command) {

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -9,6 +9,7 @@ pub trait Command {
     fn is_enabled(&self) -> bool;
     fn get_name(&self) -> String;
     fn matches_message_text(&self, message: &Message) -> bool;
+    fn stop_processing(&self) -> bool;
 }
 
 pub struct CommandDispatcher<'a> {
@@ -34,6 +35,10 @@ impl<'a> CommandDispatcher<'a> {
             if command.matches_message_text(msg) {
                 debug!("execute() for {}", command.get_name());
                 command.execute(msg, irc_sender, tg_sender);
+                if command.stop_processing() {
+                    debug!("command {} stop processing", command.get_name());
+                    break;
+                }
             }
         }
     }

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -22,7 +22,7 @@ impl NullCommand {
 impl Command for NullCommand {
     fn execute(&mut self, _: &Message, _: &Sender<Message>, _: &Sender<Message>) {}
     fn get_usage(&self) -> String {
-        return String::from("null usage")
+        return String::from("null usage");
     }
 }
 
@@ -32,7 +32,10 @@ pub struct CommandDispatcher<'a> {
 }
 
 impl<'a> CommandDispatcher<'a> {
-    pub fn new(settings: &'a settings::Commands, base_command: &'a Command) -> CommandDispatcher<'a> {
+    pub fn new(
+        settings: &'a settings::Commands,
+        base_command: &'a Command,
+    ) -> CommandDispatcher<'a> {
         CommandDispatcher {
             command: base_command,
             enabled_commands: &settings.enabled,

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -7,30 +7,34 @@ use message::Message;
 
 pub trait Command {
     fn execute(&mut self, &Message, &Sender<Message>, &Sender<Message>);
+    fn get_usage(&self) -> String;
 }
 
 #[derive(Debug)]
-struct NullCommand;
+pub struct NullCommand;
 
 impl NullCommand {
-    fn new() -> NullCommand {
+    pub fn new() -> NullCommand {
         NullCommand
     }
 }
 
 impl Command for NullCommand {
     fn execute(&mut self, _: &Message, _: &Sender<Message>, _: &Sender<Message>) {}
+    fn get_usage(&self) -> String {
+        return String::from("null usage")
+    }
 }
 
 pub struct CommandDispatcher<'a> {
-    command: Box<Command + 'a>,
+    command: &'a Command,
     enabled_commands: &'a Vec<String>,
 }
 
 impl<'a> CommandDispatcher<'a> {
-    pub fn new(settings: &'a settings::Commands) -> CommandDispatcher<'a> {
+    pub fn new(settings: &'a settings::Commands, base_command: &'a Command) -> CommandDispatcher<'a> {
         CommandDispatcher {
-            command: Box::new(NullCommand::new()),
+            command: base_command,
             enabled_commands: &settings.enabled,
         }
     }
@@ -39,12 +43,12 @@ impl<'a> CommandDispatcher<'a> {
         self.enabled_commands.into_iter().any(|x| x == command)
     }
 
-    pub fn set_command(&mut self, cmd: Box<Command + 'a>) {
+    pub fn set_command(&mut self, cmd: &'a Command) {
         self.command = cmd;
     }
 
     pub fn execute(
-        &mut self,
+        &self,
         msg: &Message,
         irc_sender: &Sender<Message>,
         tg_sender: &Sender<Message>,

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -98,10 +98,7 @@ impl<'a> Command for KarmaCommand<'a> {
     fn execute(&mut self, msg: &Message, to_irc: &Sender<Message>, to_telegram: &Sender<Message>) {
         info!("Executing KarmaCommand");
         let re_get = Regex::new(
-            format!(
-                r"^(?:{})(?:karma|riguardo)\s+(.+)$",
-                self.command_prefix
-            ).as_ref(),
+            format!(r"^(?:{})(?:karma|riguardo)\s+(.+)$", self.command_prefix).as_ref(),
         ).unwrap();
         let re_increase = Regex::new(r"^[vV]iva\s+(.*)$|^[hH]urrah\s+(.*)$|^(\w+)\+\+$").unwrap();
         let re_decrease = Regex::new(r"^[aA]bbasso\s+(.*)$|^[fF]uck\s+(.*)$|^(\w+)\-\-$").unwrap();
@@ -132,7 +129,7 @@ impl<'a> Command for KarmaCommand<'a> {
                     TransportType::Telegram,
                     karma_irc,
                     String::from("KarmaCommand"),
-                     destination_irc,
+                    destination_irc,
                     true,
                 ));
             }
@@ -149,13 +146,15 @@ impl<'a> Command for KarmaCommand<'a> {
     }
 
     fn get_usage(&self) -> String {
-        return String::from("\
+        return String::from(
+            "\
 The karma command maintains a list of strings with their karma. Use
     !karma <string> or !riguardo <string>
 to see the current karma,
     viva <string> or <string>++ or hurrah <string>
 to increment it,
     abbasso <string> or <string>-- or fuck <string>
-to decrement it.")
+to decrement it.",
+        );
     }
 }

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -147,4 +147,15 @@ impl<'a> Command for KarmaCommand<'a> {
             }
         }
     }
+
+    fn get_usage(&self) -> String {
+        return String::from("\
+The karma command maintains a list of strings with their karma. Use
+    !karma <string> or !riguardo <string>
+to see the current karma,
+    viva <string> or <string>++ or hurrah <string>
+to increment it,
+    abbasso <string> or <string>-- or fuck <string>
+to decrement it.")
+    }
 }

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -171,4 +171,8 @@ to decrement it.",
         ).unwrap();
         re.is_match(&message.text)
     }
+
+    fn stop_processing(&self) -> bool {
+        true
+    }
 }

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -21,7 +21,11 @@ pub struct KarmaCommand<'a> {
 }
 
 impl<'a> KarmaCommand<'a> {
-    pub fn new(command_prefix: &'a String, settings: &'a settings::Commands, enabled: bool) -> KarmaCommand<'a> {
+    pub fn new(
+        command_prefix: &'a String,
+        settings: &'a settings::Commands,
+        enabled: bool,
+    ) -> KarmaCommand<'a> {
         KarmaCommand {
             karma: match KarmaCommand::read_database(&settings.data_dir, "karma") {
                 Ok(v) => v,
@@ -161,10 +165,10 @@ to decrement it.",
         let re = Regex::new(
             format!(
                 r"(^{}karma\s+(.*)$|^{}riguardo\s+(.*)|^[vV]iva\s+(.*)$|^[hH]urrah\s+(.*)$|^(\w+)\+\+$|^[aA]bbasso\s+(.*)$|^[fF]uck\s+(.*)$|^(\w+)\-\-$)",
-                self.command_prefix, self.command_prefix
+                self.command_prefix,
+                self.command_prefix
             ).as_ref(),
         ).unwrap();
         re.is_match(&message.text)
     }
-
 }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -16,19 +16,19 @@ use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
 pub struct LastSeenCommand<'a> {
-    pub name: String,
     last_seen: HashMap<String, i64>,
     command_prefix: &'a String,
     data_dir: &'a String,
+    enabled: bool,
 }
 
 impl<'a> LastSeenCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         settings: &'a settings::Commands,
+        enabled: bool
     ) -> LastSeenCommand<'a> {
         LastSeenCommand {
-            name: String::from("last_seen"),
             last_seen: match LastSeenCommand::read_database(&settings.data_dir, "last_seen") {
                 Ok(v) => v,
                 Err(b) => {
@@ -38,6 +38,7 @@ impl<'a> LastSeenCommand<'a> {
             },
             command_prefix,
             data_dir: &settings.data_dir,
+            enabled,
         }
     }
 
@@ -53,7 +54,7 @@ impl<'a> LastSeenCommand<'a> {
     }
 
     fn write_database(&self) {
-        let filename = format!("{}/{}.json", self.data_dir, &self.name);
+        let filename = format!("{}/{}.json", self.data_dir, &self.get_name());
         let filename_clone = filename.clone();
         match OpenOptions::new().write(true).truncate(true).open(filename) {
             Ok(file) => {
@@ -127,5 +128,17 @@ This can be accessed via the\
     !seen <nick>\
 command. Note that all timestamps are relative to the server's timezone, usually UTC.",
         );
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn get_name(&self) -> String {
+        String::from("last_seen")
+    }
+
+    fn matches_message_text(&self, _: &Message) -> bool {
+        true
     }
 }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -11,7 +11,7 @@ use self::regex::Regex;
 use self::chrono::{Local, NaiveDateTime};
 
 use settings;
-use message::{Message, TransportType,DestinationType};
+use message::{Message, TransportType, DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
@@ -120,10 +120,12 @@ impl<'a> Command for LastSeenCommand<'a> {
     }
 
     fn get_usage(&self) -> String {
-        return String::from("\
+        return String::from(
+            "\
 The last_seen command keeps track of the last time a user sent a message to the channel the bot is in\
 This can be accessed via the\
     !seen <nick>\
-command. Note that all timestamps are relative to the server's timezone, usually UTC.")
+command. Note that all timestamps are relative to the server's timezone, usually UTC.",
+        );
     }
 }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -118,4 +118,12 @@ impl<'a> Command for LastSeenCommand<'a> {
             ));
         }
     }
+
+    fn get_usage(&self) -> String {
+        return String::from("\
+The last_seen command keeps track of the last time a user sent a message to the channel the bot is in\
+This can be accessed via the\
+    !seen <nick>\
+command. Note that all timestamps are relative to the server's timezone, usually UTC.")
+    }
 }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -26,7 +26,7 @@ impl<'a> LastSeenCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         settings: &'a settings::Commands,
-        enabled: bool
+        enabled: bool,
     ) -> LastSeenCommand<'a> {
         LastSeenCommand {
             last_seen: match LastSeenCommand::read_database(&settings.data_dir, "last_seen") {
@@ -123,7 +123,7 @@ impl<'a> Command for LastSeenCommand<'a> {
     fn get_usage(&self) -> String {
         return String::from(
             "\
-The last_seen command keeps track of the last time a user sent a message to the channel the bot is in\
+The last_seen command keeps track of the last time a user sent a message to the channel.\
 This can be accessed via the\
     !seen <nick>\
 command. Note that all timestamps are relative to the server's timezone, usually UTC.",

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -141,4 +141,8 @@ command. Note that all timestamps are relative to the server's timezone, usually
     fn matches_message_text(&self, _: &Message) -> bool {
         true
     }
+
+    fn stop_processing(&self) -> bool {
+        false
+    }
 }

--- a/holysee/src/commands/mod.rs
+++ b/holysee/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod relay;
 pub mod last_seen;
 pub mod quote;
 pub mod url_preview;
+pub mod usage;
 
 #[cfg(test)]
 mod tests {

--- a/holysee/src/commands/mod.rs
+++ b/holysee/src/commands/mod.rs
@@ -6,33 +6,35 @@ pub mod quote;
 pub mod url_preview;
 pub mod usage;
 
-#[cfg(test)]
-mod tests {
-    use commands::command_dispatcher::CommandDispatcher;
-    use settings::Settings;
 
-    #[test]
-    fn is_command_enabled_ok() {
-        let settings = match Settings::new(false) {
-            Ok(s) => s,
-            Err(e) => {
-                panic!("Error accessing config file: {}", e);
-            }
-        };
-        let command_dispatcher = CommandDispatcher::new(&settings.commands);
-        assert!(command_dispatcher.is_command_enabled("relay"));
-    }
-
-    #[test]
-    #[should_panic]
-    fn is_command_enabled_fail() {
-        let settings = match Settings::new(false) {
-            Ok(s) => s,
-            Err(e) => {
-                panic!("Error accessing config file: {}", e);
-            }
-        };
-        let command_dispatcher = CommandDispatcher::new(&settings.commands);
-        assert!(command_dispatcher.is_command_enabled("karma"));
-    }
-}
+// DISABLED DUE TO REFACTOR
+//#[cfg(test)]
+//mod tests {
+//    use commands::command_dispatcher::CommandDispatcher;
+//    use settings::Settings;
+//
+//    #[test]
+//    fn is_command_enabled_ok() {
+//        let settings = match Settings::new(false) {
+//            Ok(s) => s,
+//            Err(e) => {
+//                panic!("Error accessing config file: {}", e);
+//            }
+//        };
+//        let command_dispatcher = CommandDispatcher::new(&settings.commands);
+//        assert!(command_dispatcher.is_command_enabled("relay"));
+//    }
+//
+//    #[test]
+//    #[should_panic]
+//    fn is_command_enabled_fail() {
+//        let settings = match Settings::new(false) {
+//            Ok(s) => s,
+//            Err(e) => {
+//                panic!("Error accessing config file: {}", e);
+//            }
+//        };
+//        let command_dispatcher = CommandDispatcher::new(&settings.commands);
+//        assert!(command_dispatcher.is_command_enabled("karma"));
+//    }
+//}

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -213,4 +213,16 @@ impl<'a> Command for QuoteCommand<'a> {
             true,
         ));
     }
+
+    fn get_usage(&self) -> String {
+        return String::from("\
+The quote command maintains a list of quotes. To get a random quote run\
+    !quote\
+to add a quote use\
+    !quote add <quote>\
+to delete a quote use\
+    !quote rm <quote_id>\
+to get a specific quote run\
+    !quote <quote_id>")
+    }
 }

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -215,7 +215,8 @@ impl<'a> Command for QuoteCommand<'a> {
     }
 
     fn get_usage(&self) -> String {
-        return String::from("\
+        return String::from(
+            "\
 The quote command maintains a list of quotes. To get a random quote run\
     !quote\
 to add a quote use\
@@ -223,6 +224,7 @@ to add a quote use\
 to delete a quote use\
     !quote rm <quote_id>\
 to get a specific quote run\
-    !quote <quote_id>")
+    !quote <quote_id>",
+        );
     }
 }

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -43,7 +43,11 @@ pub struct QuoteCommand<'a> {
 }
 
 impl<'a> QuoteCommand<'a> {
-    pub fn new(command_prefix: &'a String, settings: &'a settings::Commands, enabled: bool) -> QuoteCommand<'a> {
+    pub fn new(
+        command_prefix: &'a String,
+        settings: &'a settings::Commands,
+        enabled: bool,
+    ) -> QuoteCommand<'a> {
         QuoteCommand {
             quotes: match QuoteCommand::read_database(&settings.data_dir, "quote") {
                 Ok(v) => v,

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -241,4 +241,8 @@ to get a specific quote run\
         ).unwrap();
         re.is_match(&message.text)
     }
+
+    fn stop_processing(&self) -> bool {
+        true
+    }
 }

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -150,7 +150,7 @@ impl<'a> Command for QuoteCommand<'a> {
         info!("Executing QuoteCommand");
 
         let re_get = Regex::new(
-            format!(r"^(?:{})[qQ]uote(?:\s+)$", self.command_prefix).as_ref(),
+            format!(r"^(?:{})[qQ]uote(?:\s+)?$", self.command_prefix).as_ref(),
         ).unwrap();
         let re_get_id = Regex::new(
             format!(r"^(?:{})[qQ]uote(?:\s+)(\d+)$", self.command_prefix).as_ref(),

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -79,4 +79,15 @@ impl<'a> Command for RelayMessageCommand<'a> {
             }
         }
     }
+
+    fn get_usage(&self) -> String {
+        return String::from("\
+The relay command allows to bypass the configuration allow_receive for a given transport\
+If the relay is configured with allow_receive set to false then only messages that start with\
+    !<ID> ..\
+will be relayed. So for example if you have allow_receive set to false for the telegram tranport\
+you will need to use\
+    !tg <message>\
+for message to be delivered to the chat. Similarly, use !irc for IRC.")
+    }
 }

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -102,4 +102,8 @@ for message to be delivered to the chat. Similarly, use !irc for IRC.",
         ).unwrap();
         re.is_match(&message.text)
     }
+
+    fn stop_processing(&self) -> bool {
+        true
+    }
 }

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -1,6 +1,6 @@
 extern crate regex;
 
-use message::{Message, TransportType,DestinationType};
+use message::{Message, TransportType, DestinationType};
 use chan::Sender;
 
 use self::regex::Regex;
@@ -81,13 +81,15 @@ impl<'a> Command for RelayMessageCommand<'a> {
     }
 
     fn get_usage(&self) -> String {
-        return String::from("\
+        return String::from(
+            "\
 The relay command allows to bypass the configuration allow_receive for a given transport\
 If the relay is configured with allow_receive set to false then only messages that start with\
     !<ID> ..\
 will be relayed. So for example if you have allow_receive set to false for the telegram tranport\
 you will need to use\
     !tg <message>\
-for message to be delivered to the chat. Similarly, use !irc for IRC.")
+for message to be delivered to the chat. Similarly, use !irc for IRC.",
+        );
     }
 }

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -8,10 +8,10 @@ use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
 pub struct RelayMessageCommand<'a> {
-    pub name: String,
     irc_allow_receive: &'a bool,
     telegram_allow_receive: &'a bool,
     command_prefix: &'a String,
+    enabled: bool,
 }
 
 impl<'a> RelayMessageCommand<'a> {
@@ -19,31 +19,14 @@ impl<'a> RelayMessageCommand<'a> {
         irc_allow_receive: &'a bool,
         telegram_allow_receive: &'a bool,
         command_prefix: &'a String,
+        enabled: bool,
     ) -> RelayMessageCommand<'a> {
         RelayMessageCommand {
-            name: String::from("relay"),
             irc_allow_receive,
             telegram_allow_receive,
             command_prefix,
+            enabled,
         }
-    }
-    pub fn matches_message_text(&self, message: &Message) -> bool {
-        match message.from_transport {
-            TransportType::IRC => {
-                if *self.telegram_allow_receive || message.is_from_command {
-                    return true;
-                }
-            }
-            TransportType::Telegram => {
-                if *self.irc_allow_receive || message.is_from_command {
-                    return true;
-                }
-            }
-        };
-        let re = Regex::new(
-            format!(r"^({})(irc|tg)\s+(.*)$", self.command_prefix).as_ref(),
-        ).unwrap();
-        re.is_match(&message.text)
     }
 }
 
@@ -91,5 +74,32 @@ you will need to use\
     !tg <message>\
 for message to be delivered to the chat. Similarly, use !irc for IRC.",
         );
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn get_name(&self) -> String {
+        String::from("relay")
+    }
+
+    fn matches_message_text(&self, message: &Message) -> bool {
+        match message.from_transport {
+            TransportType::IRC => {
+                if *self.telegram_allow_receive || message.is_from_command {
+                    return true;
+                }
+            }
+            TransportType::Telegram => {
+                if *self.irc_allow_receive || message.is_from_command {
+                    return true;
+                }
+            }
+        };
+        let re = Regex::new(
+            format!(r"^({})(irc|tg)\s+(.*)$", self.command_prefix).as_ref(),
+        ).unwrap();
+        re.is_match(&message.text)
     }
 }

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -83,4 +83,8 @@ impl Command for UrlPreviewCommand {
             });
         }
     }
+
+    fn get_usage(&self) -> String {
+        return String::from("This command is not a real command, therefore it has no usage")
+    }
 }

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -19,9 +19,7 @@ pub struct UrlPreviewCommand {
 
 impl UrlPreviewCommand {
     pub fn new(enabled: bool) -> UrlPreviewCommand {
-        UrlPreviewCommand {
-            enabled,
-        }
+        UrlPreviewCommand { enabled }
     }
 
     fn get(
@@ -77,7 +75,9 @@ impl UrlPreviewCommand {
 impl Command for UrlPreviewCommand {
     fn execute(&mut self, msg: &Message, to_irc: &Sender<Message>, to_telegram: &Sender<Message>) {
         info!("Executing UrlPreviewCommand");
-        let re = regex::Regex::new(r"(https?://(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:;%()\[\]{}_\+.*~#?,&//=]*))").unwrap();
+        let re = regex::Regex::new(
+            r"(https?://(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:;%()\[\]{}_\+.*~#?,&//=]*))",
+        ).unwrap();
 
         // COMMAND HANDLING
         let message_text = msg.text.to_owned();

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -110,4 +110,8 @@ impl Command for UrlPreviewCommand {
     fn matches_message_text(&self, _: &Message) -> bool {
         true
     }
+
+    fn stop_processing(&self) -> bool {
+        false
+    }
 }

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -14,12 +14,14 @@ use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
 pub struct UrlPreviewCommand {
-    pub name: String,
+    enabled: bool,
 }
 
 impl UrlPreviewCommand {
-    pub fn new() -> UrlPreviewCommand {
-        UrlPreviewCommand { name: String::from("url_preview") }
+    pub fn new(enabled: bool) -> UrlPreviewCommand {
+        UrlPreviewCommand {
+            enabled,
+        }
     }
 
     fn get(
@@ -95,5 +97,17 @@ impl Command for UrlPreviewCommand {
         return String::from(
             "This command is not a real command, therefore it has no usage",
         );
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn get_name(&self) -> String {
+        String::from("url_preview")
+    }
+
+    fn matches_message_text(&self, _: &Message) -> bool {
+        true
     }
 }

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -22,7 +22,12 @@ impl UrlPreviewCommand {
         UrlPreviewCommand { name: String::from("url_preview") }
     }
 
-    fn get(url: &String, destination: DestinationType,  to_irc: &Sender<Message>, to_telegram: &Sender<Message>) {
+    fn get(
+        url: &String,
+        destination: DestinationType,
+        to_irc: &Sender<Message>,
+        to_telegram: &Sender<Message>,
+    ) {
         let result = reqwest::get(url);
         match result {
             Ok(mut resp) => {
@@ -39,8 +44,10 @@ impl UrlPreviewCommand {
                         let title_irc = x.as_text().unwrap();
                         debug!("extracted url: {}", title_irc);
                         let title_telegram = title_irc;
-                        let destination_irc: DestinationType = DestinationType::klone(&destination_inner);
-                        let destination_telegram: DestinationType = DestinationType::klone(&destination_inner);
+                        let destination_irc: DestinationType =
+                            DestinationType::klone(&destination_inner);
+                        let destination_telegram: DestinationType =
+                            DestinationType::klone(&destination_inner);
                         to_irc.send(Message::new(
                             TransportType::Telegram,
                             title_irc.to_owned(),
@@ -79,12 +86,14 @@ impl Command for UrlPreviewCommand {
             let destination: DestinationType = DestinationType::klone(&msg.to);
             debug!("Previewing url {}", url);
             thread::spawn(move || {
-                UrlPreviewCommand::get(&url, destination,  &to_irc_clone, &to_telegram_clone)
+                UrlPreviewCommand::get(&url, destination, &to_irc_clone, &to_telegram_clone)
             });
         }
     }
 
     fn get_usage(&self) -> String {
-        return String::from("This command is not a real command, therefore it has no usage")
+        return String::from(
+            "This command is not a real command, therefore it has no usage",
+        );
     }
 }

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -90,4 +90,8 @@ impl<'a> Command for UsageCommand<'a> {
         ).unwrap();
         re.is_match(&message.text)
     }
+
+    fn stop_processing(&self) -> bool {
+        true
+    }
 }

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -79,6 +79,6 @@ impl<'a> Command for UsageCommand<'a> {
     }
 
     fn get_usage(&self) -> String {
-        return String::from("Run via !usage, it retuns this help")
+        return String::from("Run via !usage, it retuns this help");
     }
 }

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -1,0 +1,84 @@
+extern crate regex;
+
+use chan::Sender;
+use std::collections::HashMap;
+
+use self::regex::Regex;
+
+use message::{Message, TransportType,DestinationType};
+use commands::command_dispatcher::Command;
+
+#[derive(Debug)]
+pub struct UsageCommand<'a> {
+    pub name: String,
+    command_prefix: &'a String,
+    commands: &'a HashMap<String, String>,
+}
+
+impl<'a> UsageCommand<'a> {
+    pub fn new(
+        command_prefix: &'a String,
+        commands: &'a mut HashMap<String, String>,
+    ) -> UsageCommand<'a> {
+        UsageCommand {
+            name: String::from("usage"),
+            command_prefix,
+            commands,
+        }
+    }
+
+    pub fn matches_message_text(&self, message: &Message) -> bool {
+        let re = Regex::new(
+            // the shame cannot be forgotten
+            format!(r"^(?:{})(?:[uU]sage)\s+(.*)$", self.command_prefix).as_ref(),
+        ).unwrap();
+        re.is_match(&message.text)
+    }
+}
+
+impl<'a> Command for UsageCommand<'a> {
+    fn execute(&mut self, msg: &Message, to_irc: &Sender<Message>, to_telegram: &Sender<Message>) {
+        info!("Executing UsageCommand");
+        let re_get = Regex::new(
+            format!(r"^(?:{})usage\s+(.*)$", &self.command_prefix).as_ref(),
+        ).unwrap();
+
+        // COMMAND HANDLING
+        for cap in re_get.captures_iter(&msg.text) {
+            debug!("Usage captures {:#?}", cap);
+            let command_name = &cap[1];
+            let mut usage_string = String::new();
+            for (cmd_name, cmd_usage) in self.commands.iter() {
+                if *cmd_name == command_name {
+                    usage_string = String::from(cmd_usage.clone());
+                } else {
+                    usage_string = String::from(format!("Command {} not found", command_name));
+                }
+            }
+
+            let usage_string_irc = usage_string.clone();
+            let usage_string_telegra = usage_string.clone();
+            let destination_irc: DestinationType = DestinationType::klone(&msg.to);
+            let destination_telegram: DestinationType = DestinationType::klone(&msg.to);
+            // SEND MESSAGES
+            to_irc.send(Message::new(
+                TransportType::Telegram,
+                usage_string_irc,
+                String::from("UsageCommand"),
+                destination_irc,
+                true,
+            ));
+            to_telegram.send(Message::new(
+                TransportType::IRC,
+                usage_string_telegra,
+                String::from("UsageCommand"),
+                destination_telegram,
+                true,
+            ));
+        }
+    }
+
+    fn get_usage(&self) -> String {
+        return String::from("Run via !usage, it retuns this help")
+    }
+}

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use self::regex::Regex;
 
-use message::{Message, TransportType,DestinationType};
+use message::{Message, TransportType, DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug)]

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -10,29 +10,22 @@ use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
 pub struct UsageCommand<'a> {
-    pub name: String,
     command_prefix: &'a String,
     commands: &'a HashMap<String, String>,
+    enabled: bool,
 }
 
 impl<'a> UsageCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         commands: &'a mut HashMap<String, String>,
+        enabled: bool,
     ) -> UsageCommand<'a> {
         UsageCommand {
-            name: String::from("usage"),
             command_prefix,
             commands,
+            enabled,
         }
-    }
-
-    pub fn matches_message_text(&self, message: &Message) -> bool {
-        let re = Regex::new(
-            // the shame cannot be forgotten
-            format!(r"^(?:{})(?:[uU]sage)\s+(.*)$", self.command_prefix).as_ref(),
-        ).unwrap();
-        re.is_match(&message.text)
     }
 }
 
@@ -80,5 +73,21 @@ impl<'a> Command for UsageCommand<'a> {
 
     fn get_usage(&self) -> String {
         return String::from("Run via !usage, it retuns this help");
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn get_name(&self) -> String {
+        String::from("usage")
+    }
+
+    fn matches_message_text(&self, message: &Message) -> bool {
+        let re = Regex::new(
+            // the shame cannot be forgotten
+            format!(r"^(?:{})(?:[uU]sage)\s+(.*)$", self.command_prefix).as_ref(),
+        ).unwrap();
+        re.is_match(&message.text)
     }
 }

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -78,7 +78,6 @@ fn main() {
         url_preview_command.get_usage().clone(),
     );
     let mut usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap, true);
-    //let mut command_dispatcher = CommandDispatcher::new(&settings.commands);
     let mut command_dispatcher = CommandDispatcher::new();
 
     // FILTERS

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -56,11 +56,27 @@ fn main() {
     let last_seen_command = LastSeenCommand::new(&settings.command_prefix, &settings.commands);
     let quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
     let url_preview_command = UrlPreviewCommand::new();
-    let relay_command = RelayMessageCommand::new(&settings.irc.allow_receive,&settings.telegram.allow_receive,&settings.command_prefix);
-    usage_hashmap.insert(karma_command.name.clone(), karma_command.get_usage().clone());
-    usage_hashmap.insert(quote_command.name.clone(), quote_command.get_usage().clone());
-    usage_hashmap.insert(last_seen_command.name.clone(), last_seen_command.get_usage().clone());
-    usage_hashmap.insert(url_preview_command.name.clone(), url_preview_command.get_usage().clone());
+    let relay_command = RelayMessageCommand::new(
+        &settings.irc.allow_receive,
+        &settings.telegram.allow_receive,
+        &settings.command_prefix,
+    );
+    usage_hashmap.insert(
+        karma_command.name.clone(),
+        karma_command.get_usage().clone(),
+    );
+    usage_hashmap.insert(
+        quote_command.name.clone(),
+        quote_command.get_usage().clone(),
+    );
+    usage_hashmap.insert(
+        last_seen_command.name.clone(),
+        last_seen_command.get_usage().clone(),
+    );
+    usage_hashmap.insert(
+        url_preview_command.name.clone(),
+        url_preview_command.get_usage().clone(),
+    );
     let usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap);
     let mut command_dispatcher = CommandDispatcher::new(&settings.commands, &null_command);
 
@@ -126,7 +142,7 @@ fn main() {
             command_dispatcher.execute(&current_message, &irc_client, &telegram_client);
         // usage command
         } else if command_dispatcher.is_command_enabled(&usage_command.name) &&
-            usage_command.matches_message_text(&current_message)
+                   usage_command.matches_message_text(&current_message)
         {
             command_dispatcher.set_command(&usage_command);
             command_dispatcher.execute(&current_message, &irc_client, &telegram_client);

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -52,14 +52,15 @@ fn main() {
     info!("Starting Holysee");
 
     let mut karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands, true);
-    let mut last_seen_command = LastSeenCommand::new(&settings.command_prefix, &settings.commands, true);
+    let mut last_seen_command =
+        LastSeenCommand::new(&settings.command_prefix, &settings.commands, true);
     let mut quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands, true);
     let mut url_preview_command = UrlPreviewCommand::new(true);
     let mut relay_command = RelayMessageCommand::new(
         &settings.irc.allow_receive,
         &settings.telegram.allow_receive,
         &settings.command_prefix,
-        true
+        true,
     );
     usage_hashmap.insert(
         karma_command.get_name().clone(),

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -89,10 +89,11 @@ fn main() {
     command_dispatcher.register(&mut karma_command);
     // quote command
     command_dispatcher.register(&mut quote_command);
-    // relay command
-    command_dispatcher.register(&mut relay_command);
     // usage command
     command_dispatcher.register(&mut usage_command);
+    // relay command
+    command_dispatcher.register(&mut relay_command);
+
 
     loop {
         let current_message: Message;

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -19,18 +19,21 @@ mod message;
 mod commands;
 
 use std::process;
+use std::collections::HashMap;
 use settings::Settings;
 use message::Message;
+use commands::command_dispatcher::{Command, NullCommand};
 use commands::last_seen::LastSeenCommand;
 use commands::relay::RelayMessageCommand;
 use commands::karma::KarmaCommand;
 use commands::command_dispatcher::CommandDispatcher;
 use commands::quote::QuoteCommand;
 use commands::url_preview::UrlPreviewCommand;
+use commands::usage::UsageCommand;
 
 fn main() {
     pretty_env_logger::init().unwrap();
-
+    let mut h: HashMap<String, String> = HashMap::new();
     let settings = match Settings::new(true) {
         Ok(s) => s,
         Err(e) => {
@@ -48,7 +51,18 @@ fn main() {
 
     info!("Starting Holysee");
 
-    let mut command_dispatcher = CommandDispatcher::new(&settings.commands);
+    let null_command = NullCommand::new();
+    let karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands);
+    let last_seen_command = LastSeenCommand::new(&settings.command_prefix, &settings.commands);
+    let quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
+    let url_preview_command = UrlPreviewCommand::new();
+    let relay_command = RelayMessageCommand::new(&settings.irc.allow_receive,&settings.telegram.allow_receive,&settings.command_prefix);
+    h.insert(karma_command.name.clone(), karma_command.get_usage().clone());
+    h.insert(quote_command.name.clone(), quote_command.get_usage().clone());
+    h.insert(last_seen_command.name.clone(), last_seen_command.get_usage().clone());
+    h.insert(url_preview_command.name.clone(), url_preview_command.get_usage().clone());
+    let usage_command = UsageCommand::new(&settings.command_prefix, &mut h);
+    let mut command_dispatcher = CommandDispatcher::new(&settings.commands, &null_command);
 
     loop {
         let current_message: Message;
@@ -81,23 +95,13 @@ fn main() {
 
         debug!("Current HolySee message: {:#?}", current_message);
 
-        let relay_command = RelayMessageCommand::new(
-            &settings.irc.allow_receive,
-            &settings.telegram.allow_receive,
-            &settings.command_prefix,
-        );
-        let karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands);
-        let last_seen_command = LastSeenCommand::new(&settings.command_prefix, &settings.commands);
-        let quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
-        let url_preview_command = UrlPreviewCommand::new();
-
         // FILTERS
         if command_dispatcher.is_command_enabled(&last_seen_command.name) {
-            command_dispatcher.set_command(Box::new(last_seen_command));
+            command_dispatcher.set_command(&last_seen_command);
             command_dispatcher.execute(&current_message, &to_irc, &to_telegram);
         }
         if command_dispatcher.is_command_enabled(&url_preview_command.name) {
-            command_dispatcher.set_command(Box::new(url_preview_command));
+            command_dispatcher.set_command(&url_preview_command);
             command_dispatcher.execute(&current_message, &to_irc, &to_telegram);
         }
 
@@ -106,20 +110,27 @@ fn main() {
         if command_dispatcher.is_command_enabled(&karma_command.name) &&
             karma_command.matches_message_text(&current_message)
         {
-            command_dispatcher.set_command(Box::new(karma_command));
+            command_dispatcher.set_command(&karma_command);
             command_dispatcher.execute(&current_message, &to_irc, &to_telegram);
         // quote command
         } else if command_dispatcher.is_command_enabled(&quote_command.name) &&
                    quote_command.matches_message_text(&current_message)
         {
-            command_dispatcher.set_command(Box::new(quote_command));
+            command_dispatcher.set_command(&quote_command);
             command_dispatcher.execute(&current_message, &to_irc, &to_telegram);
         // relay command
         } else if command_dispatcher.is_command_enabled(&relay_command.name) &&
                    relay_command.matches_message_text(&current_message)
         {
-            command_dispatcher.set_command(Box::new(relay_command));
+            command_dispatcher.set_command(&relay_command);
+            command_dispatcher.execute(&current_message, &irc_client, &telegram_client);
+        // usage command
+        } else if command_dispatcher.is_command_enabled(&usage_command.name) &&
+            usage_command.matches_message_text(&current_message)
+        {
+            command_dispatcher.set_command(&usage_command);
             command_dispatcher.execute(&current_message, &irc_client, &telegram_client);
         }
+
     }
 }

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -33,7 +33,7 @@ use commands::usage::UsageCommand;
 
 fn main() {
     pretty_env_logger::init().unwrap();
-    let mut h: HashMap<String, String> = HashMap::new();
+    let mut usage_hashmap: HashMap<String, String> = HashMap::new();
     let settings = match Settings::new(true) {
         Ok(s) => s,
         Err(e) => {
@@ -57,11 +57,11 @@ fn main() {
     let quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
     let url_preview_command = UrlPreviewCommand::new();
     let relay_command = RelayMessageCommand::new(&settings.irc.allow_receive,&settings.telegram.allow_receive,&settings.command_prefix);
-    h.insert(karma_command.name.clone(), karma_command.get_usage().clone());
-    h.insert(quote_command.name.clone(), quote_command.get_usage().clone());
-    h.insert(last_seen_command.name.clone(), last_seen_command.get_usage().clone());
-    h.insert(url_preview_command.name.clone(), url_preview_command.get_usage().clone());
-    let usage_command = UsageCommand::new(&settings.command_prefix, &mut h);
+    usage_hashmap.insert(karma_command.name.clone(), karma_command.get_usage().clone());
+    usage_hashmap.insert(quote_command.name.clone(), quote_command.get_usage().clone());
+    usage_hashmap.insert(last_seen_command.name.clone(), last_seen_command.get_usage().clone());
+    usage_hashmap.insert(url_preview_command.name.clone(), url_preview_command.get_usage().clone());
+    let usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap);
     let mut command_dispatcher = CommandDispatcher::new(&settings.commands, &null_command);
 
     loop {

--- a/holysee/src/message.rs
+++ b/holysee/src/message.rs
@@ -16,14 +16,10 @@ pub enum DestinationType {
 }
 
 impl DestinationType {
-    pub fn klone(other: &DestinationType) -> DestinationType{
+    pub fn klone(other: &DestinationType) -> DestinationType {
         match other {
-            &DestinationType::Channel(ref s) => {
-                DestinationType::Channel(String::from(s.clone()))
-            },
-            &DestinationType::User(ref u) => {
-                DestinationType::Channel(String::from(u.clone()))
-            },
+            &DestinationType::Channel(ref s) => DestinationType::Channel(String::from(s.clone())),
+            &DestinationType::User(ref u) => DestinationType::Channel(String::from(u.clone())),
             &DestinationType::Unknown => DestinationType::Unknown,
         }
     }

--- a/holysee/src/telegram.rs
+++ b/holysee/src/telegram.rs
@@ -50,7 +50,7 @@ pub mod client {
                                         match u.username {
                                             // if username is provided, use it
                                             Some(username) => username,
-                                            // if username is not provided, try telegram profile names
+                                            // username is not provided,use telegram profile names
                                             None => {
                                                 // first_name always contains something
                                                 match u.last_name {
@@ -72,7 +72,14 @@ pub mod client {
                                     Chat::Channel(c) => DestinationType::Channel(c.title),
                                     Chat::Unknown(_) => DestinationType::Unknown,
                                 };
-                                debug!("Incoming Telegram message source: #cattedrale, text: {}, src_nick: {}, to: {:?}, entities: {:?}", data, from, to, entities);
+                                debug!(
+                                    "Incoming Telegram message source: #cattedrale, \
+                                text: {}, src_nick: {}, to: {:?}, entities: {:?}",
+                                    data,
+                                    from,
+                                    to,
+                                    entities
+                                );
                                 to_main_queue.send(Message::new(
                                     TransportType::Telegram,
                                     data,


### PR DESCRIPTION
this code does _not_ compile at the moment.
My plan is to be able to create all the commands and the command dispatcher _outside_ of the loop in the main thread and use their reference as a command to be able to address them in the command dispatcher. i am not sure this is the right way to go, i fear it might require us to rework the whole command interface. any comments are welcome.

the change in itself is not huge, since rust does not support variadic functions and iterating on a Vec of Commands cannot be done (or i haven't been able to) the plan was to get the usage at the beginning of the main() and then return that each time it's needed. 
missing:
- privmsg handling
- destination type routing in both telegram and irc tranports
- decent logging