### PR TITLE
Remove useless trait `is_enabled` from Command 

### DIFF
--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -6,7 +6,6 @@ use message::Message;
 pub trait Command {
     fn execute(&mut self, &mut Message, &Sender<Message>, &Sender<Message>);
     fn get_usage(&self) -> String;
-    fn is_enabled(&self) -> bool;
     fn get_name(&self) -> String;
     fn matches_message_text(&self, message: &Message) -> bool;
     fn stop_processing(&self) -> bool;

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -13,15 +13,28 @@ pub trait Command {
 
 pub struct CommandDispatcher<'a> {
     commands: Vec<&'a mut Command>,
+    enabled_commands: &'a[String],
 }
 
 impl<'a> CommandDispatcher<'a> {
-    pub fn new() -> CommandDispatcher<'a> {
-        CommandDispatcher { commands: vec![] }
+    pub fn new(enabled_commands: &'a[String]) -> CommandDispatcher<'a> {
+        CommandDispatcher { commands: vec![], enabled_commands}
+    }
+
+    pub fn is_command_enabled(&self, command: &str) -> bool {
+        self.enabled_commands.into_iter().any(|x| x == command)
     }
 
     pub fn register(&mut self, cmd: &'a mut Command) {
-        self.commands.push(cmd);
+        if self.is_command_enabled(&cmd.get_name()) {
+            info!("Registering new command {}", cmd.get_name());
+            self.commands.push(cmd);
+        } else {
+            warn!(
+                "Command {} is disabled in settings, skipping registration",
+                cmd.get_name()
+            );
+        }
     }
 
     pub fn execute(

--- a/holysee/src/commands/command_dispatcher.rs
+++ b/holysee/src/commands/command_dispatcher.rs
@@ -13,12 +13,15 @@ pub trait Command {
 
 pub struct CommandDispatcher<'a> {
     commands: Vec<&'a mut Command>,
-    enabled_commands: &'a[String],
+    enabled_commands: &'a [String],
 }
 
 impl<'a> CommandDispatcher<'a> {
-    pub fn new(enabled_commands: &'a[String]) -> CommandDispatcher<'a> {
-        CommandDispatcher { commands: vec![], enabled_commands}
+    pub fn new(enabled_commands: &'a [String]) -> CommandDispatcher<'a> {
+        CommandDispatcher {
+            commands: vec![],
+            enabled_commands,
+        }
     }
 
     pub fn is_command_enabled(&self, command: &str) -> bool {

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -20,10 +20,7 @@ pub struct KarmaCommand<'a> {
 }
 
 impl<'a> KarmaCommand<'a> {
-    pub fn new(
-        command_prefix: &'a String,
-        settings: &'a settings::Commands,
-    ) -> KarmaCommand<'a> {
+    pub fn new(command_prefix: &'a String, settings: &'a settings::Commands) -> KarmaCommand<'a> {
         KarmaCommand {
             karma: match KarmaCommand::read_database(&settings.data_dir, "karma") {
                 Ok(v) => v,

--- a/holysee/src/commands/karma.rs
+++ b/holysee/src/commands/karma.rs
@@ -14,7 +14,6 @@ use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
 pub struct KarmaCommand<'a> {
-    enabled: bool,
     karma: HashMap<String, i64>,
     command_prefix: &'a String,
     data_dir: &'a String,
@@ -24,7 +23,6 @@ impl<'a> KarmaCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         settings: &'a settings::Commands,
-        enabled: bool,
     ) -> KarmaCommand<'a> {
         KarmaCommand {
             karma: match KarmaCommand::read_database(&settings.data_dir, "karma") {
@@ -34,7 +32,6 @@ impl<'a> KarmaCommand<'a> {
                     HashMap::new()
                 }
             },
-            enabled,
             command_prefix: command_prefix,
             data_dir: &settings.data_dir,
         }
@@ -160,10 +157,6 @@ to increment it,
     abbasso <string> or <string>-- or fuck <string>
 to decrement it.",
         )
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     fn get_name(&self) -> String {

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -145,10 +145,6 @@ command. Note that all timestamps are relative to the server's timezone, usually
         )
     }
 
-    fn is_enabled(&self) -> bool {
-        self.enabled
-    }
-
     fn get_name(&self) -> String {
         String::from("last_seen")
     }

--- a/holysee/src/commands/last_seen.rs
+++ b/holysee/src/commands/last_seen.rs
@@ -19,14 +19,12 @@ pub struct LastSeenCommand<'a> {
     last_seen: HashMap<String, i64>,
     command_prefix: &'a String,
     data_dir: &'a String,
-    enabled: bool,
 }
 
 impl<'a> LastSeenCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         settings: &'a settings::Commands,
-        enabled: bool,
     ) -> LastSeenCommand<'a> {
         LastSeenCommand {
             last_seen: match LastSeenCommand::read_database(&settings.data_dir, "last_seen") {
@@ -38,11 +36,10 @@ impl<'a> LastSeenCommand<'a> {
             },
             command_prefix,
             data_dir: &settings.data_dir,
-            enabled,
         }
     }
 
-    fn read_database(data_dir: &String, name: &str) -> Result<HashMap<String, i64>, Box<Error>> {
+    fn read_database(data_dir: &str, name: &str) -> Result<HashMap<String, i64>, Box<Error>> {
         let filename = format!("{}/{}.json", data_dir, name);
         let filename_clone = filename.clone();
         let file = OpenOptions::new().read(true).open(filename)?;

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -42,10 +42,7 @@ pub struct QuoteCommand<'a> {
 }
 
 impl<'a> QuoteCommand<'a> {
-    pub fn new(
-        command_prefix: &'a String,
-        settings: &'a settings::Commands,
-    ) -> QuoteCommand<'a> {
+    pub fn new(command_prefix: &'a String, settings: &'a settings::Commands) -> QuoteCommand<'a> {
         QuoteCommand {
             quotes: match QuoteCommand::read_database(&settings.data_dir, "quote") {
                 Ok(v) => v,

--- a/holysee/src/commands/quote.rs
+++ b/holysee/src/commands/quote.rs
@@ -39,14 +39,12 @@ pub struct QuoteCommand<'a> {
     quotes: Vec<Quote>,
     command_prefix: &'a String,
     data_dir: &'a String,
-    enabled: bool,
 }
 
 impl<'a> QuoteCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         settings: &'a settings::Commands,
-        enabled: bool,
     ) -> QuoteCommand<'a> {
         QuoteCommand {
             quotes: match QuoteCommand::read_database(&settings.data_dir, "quote") {
@@ -58,7 +56,6 @@ impl<'a> QuoteCommand<'a> {
             },
             command_prefix,
             data_dir: &settings.data_dir,
-            enabled,
         }
     }
 
@@ -238,10 +235,6 @@ to delete a quote use\
 to get a specific quote run\
     !quote <quote_id>",
         )
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     fn get_name(&self) -> String {

--- a/holysee/src/commands/relay.rs
+++ b/holysee/src/commands/relay.rs
@@ -12,7 +12,6 @@ pub struct RelayMessageCommand<'a> {
     irc_allow_receive: &'a bool,
     telegram_allow_receive: &'a bool,
     command_prefix: &'a String,
-    enabled: bool,
     nicknames: &'a [NickEntry],
 }
 
@@ -21,14 +20,12 @@ impl<'a> RelayMessageCommand<'a> {
         irc_allow_receive: &'a bool,
         telegram_allow_receive: &'a bool,
         command_prefix: &'a String,
-        enabled: bool,
         nicknames: &'a [NickEntry],
     ) -> RelayMessageCommand<'a> {
         RelayMessageCommand {
             irc_allow_receive,
             telegram_allow_receive,
             command_prefix,
-            enabled,
             nicknames,
         }
     }
@@ -79,10 +76,6 @@ you will need to use\
     !tg <message>\
 for message to be delivered to the chat. Similarly, use !irc for IRC.",
         )
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     fn get_name(&self) -> String {

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -13,13 +13,11 @@ use message::{Message, TransportType, DestinationType};
 use commands::command_dispatcher::Command;
 
 #[derive(Debug)]
-pub struct UrlPreviewCommand {
-    enabled: bool,
-}
+pub struct UrlPreviewCommand {}
 
 impl UrlPreviewCommand {
-    pub fn new(enabled: bool) -> UrlPreviewCommand {
-        UrlPreviewCommand { enabled }
+    pub fn new() -> UrlPreviewCommand {
+        UrlPreviewCommand { }
     }
 
     fn get(
@@ -110,10 +108,6 @@ impl Command for UrlPreviewCommand {
         String::from(
             "This command is not a real command, therefore it has no usage",
         )
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     fn get_name(&self) -> String {

--- a/holysee/src/commands/url_preview.rs
+++ b/holysee/src/commands/url_preview.rs
@@ -17,13 +17,13 @@ pub struct UrlPreviewCommand {}
 
 impl UrlPreviewCommand {
     pub fn new() -> UrlPreviewCommand {
-        UrlPreviewCommand { }
+        UrlPreviewCommand {}
     }
 
     fn get(
-        url: &String,
+        url: &str,
         destination: &DestinationType,
-        from: &String,
+        from: &str,
         to_irc: &Sender<Message>,
         to_telegram: &Sender<Message>,
     ) {
@@ -40,7 +40,7 @@ impl UrlPreviewCommand {
                     println!("{:#?}", node);
                     let destination_inner = match *destination {
                         DestinationType::Channel(ref c) => DestinationType::Channel(c.clone()),
-                        DestinationType::User(_) => DestinationType::User(from.clone()),
+                        DestinationType::User(_) => DestinationType::User(from.to_string()),
                         DestinationType::Unknown => {
                             panic!("Serious bug in url_preview command handler")
                         }

--- a/holysee/src/commands/usage.rs
+++ b/holysee/src/commands/usage.rs
@@ -12,14 +12,12 @@ use commands::command_dispatcher::Command;
 pub struct UsageCommand<'a> {
     command_prefix: &'a String,
     commands: &'a HashMap<String, String>,
-    enabled: bool,
 }
 
 impl<'a> UsageCommand<'a> {
     pub fn new(
         command_prefix: &'a String,
         commands: &'a mut HashMap<String, String>,
-        enabled: bool,
     ) -> UsageCommand<'a> {
         debug!(
             "Created usage command with usages for: {:#?}",
@@ -28,7 +26,6 @@ impl<'a> UsageCommand<'a> {
         UsageCommand {
             command_prefix,
             commands,
-            enabled,
         }
     }
 }
@@ -111,10 +108,6 @@ impl<'a> Command for UsageCommand<'a> {
         Available commands: {:#?}",
             self.commands.keys().collect::<Vec<&String>>()
         )
-    }
-
-    fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     fn get_name(&self) -> String {

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -51,16 +51,15 @@ fn main() {
 
     info!("Starting Holysee");
 
-    let mut karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands, true);
+    let mut karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands);
     let mut last_seen_command =
         LastSeenCommand::new(&settings.command_prefix, &settings.commands, true);
-    let mut quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands, true);
-    let mut url_preview_command = UrlPreviewCommand::new(true);
+    let mut quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
+    let mut url_preview_command = UrlPreviewCommand::new();
     let mut relay_command = RelayMessageCommand::new(
         &settings.irc.allow_receive,
         &settings.telegram.allow_receive,
         &settings.command_prefix,
-        true,
         &settings.nicknames,
     );
     usage_hashmap.insert(
@@ -79,7 +78,7 @@ fn main() {
         url_preview_command.get_name().clone(),
         url_preview_command.get_usage().clone(),
     );
-    let mut usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap, true);
+    let mut usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap);
     let mut command_dispatcher = CommandDispatcher::new();
 
     // FILTERS

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -34,13 +34,16 @@ use commands::usage::UsageCommand;
 fn main() {
     pretty_env_logger::init().unwrap();
     let mut usage_hashmap: HashMap<String, String> = HashMap::new();
-    let settings = match Settings::new(true) {
+    let mut settings = match Settings::new(true) {
         Ok(s) => s,
         Err(e) => {
             error!("Error accessing config file: {}", e);
             process::exit(1)
         }
     };
+
+    // relay command is always enabled
+    Settings::enable_relay_command(&mut settings);
 
     // TODO: fix this hardcoded value
     let (to_irc, from_irc) = chan::sync(100);

--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -52,8 +52,7 @@ fn main() {
     info!("Starting Holysee");
 
     let mut karma_command = KarmaCommand::new(&settings.command_prefix, &settings.commands);
-    let mut last_seen_command =
-        LastSeenCommand::new(&settings.command_prefix, &settings.commands, true);
+    let mut last_seen_command = LastSeenCommand::new(&settings.command_prefix, &settings.commands);
     let mut quote_command = QuoteCommand::new(&settings.command_prefix, &settings.commands);
     let mut url_preview_command = UrlPreviewCommand::new();
     let mut relay_command = RelayMessageCommand::new(
@@ -79,7 +78,7 @@ fn main() {
         url_preview_command.get_usage().clone(),
     );
     let mut usage_command = UsageCommand::new(&settings.command_prefix, &mut usage_hashmap);
-    let mut command_dispatcher = CommandDispatcher::new();
+    let mut command_dispatcher = CommandDispatcher::new(&settings.commands.enabled);
 
     // FILTERS
     command_dispatcher.register(&mut last_seen_command);

--- a/holysee/src/settings.rs
+++ b/holysee/src/settings.rs
@@ -54,4 +54,8 @@ impl Settings {
         }
         s.deserialize()
     }
+
+    pub fn enable_relay_command(settings: &mut Settings) {
+        settings.commands.enabled.push(String::from("relay"));
+    }
 }


### PR DESCRIPTION
`is_enabled()` is useless since we loop on all commands enabled in configuration in the command dispatcher.

I have reimplemented `is_command_enabled()` inside the dispatcher and used it to decide if a command registration is due or not.

Example from logs:

```
DEBUG:holysee::commands::usage  : Created usage command with usages for: [
    "url_preview",
    "karma",
    "quote",
    "last_seen"
]
INFO :holysee::commands::command_dispatcher: Registering new command last_seen
INFO :holysee::commands::command_dispatcher: Registering new command url_preview
INFO :holysee::commands::command_dispatcher: Registering new command karma
INFO :holysee::commands::command_dispatcher: Registering new command quote
WARN :holysee::commands::command_dispatcher: Command usage is disabled in settings, skipping registration
INFO :holysee::commands::command_dispatcher: Registering new command relay
```

Relay command is also auto enabled now.