### PR TITLE
Fix UrlPreviewCommand and allow_receive

### DIFF
--- a/holysee/src/main.rs
+++ b/holysee/src/main.rs
@@ -60,7 +60,10 @@ fn main() {
         LastSeenCommand::new(&settings.command_prefix, &settings.commands.data_dir);
     let mut quote_command =
         QuoteCommand::new(&settings.command_prefix, &settings.commands.data_dir);
-    let mut url_preview_command = UrlPreviewCommand::new();
+    let mut url_preview_command = UrlPreviewCommand::new(
+        settings.irc.allow_receive,
+        settings.telegram.allow_receive,
+    );
     let mut relay_command = RelayMessageCommand::new(
         &settings.irc.allow_receive,
         &settings.telegram.allow_receive,


### PR DESCRIPTION
The current implementation of the allow_receive lives in the `relay` command. This might be inconvenient, as i feel it might be best to have it be an attribute of the transport itself and then add a field to the message itself like `pushed` or similar to signal the transport that the message was prefixed with the !tg/!irc command, but this is a larger refactor that might come in handy in the future.

Anyway, this fixes #20 by cloning the `allow_receive` flags on the `UrlPreviewCommand` so that it only sends to the queues if enabled.

Test run and passing.